### PR TITLE
chore: update genai-toolbox repo deps name

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,7 @@
       pinDigests: true,
     },
     {
-      matchPackageNames: ['googleapis/genai-toolbox'],
+      matchPackageNames: ['googleapis/mcp-toolbox'],
       'semanticCommitType': 'feat'
     }
   ],
@@ -31,7 +31,7 @@
       managerFilePatterns: ["/toolbox_version\\.txt$/"],
       matchStrings: ["(?<currentValue>[\\d\\.]+)"],
       datasourceTemplate: "github-releases",
-      packageNameTemplate: "googleapis/genai-toolbox",
+      packageNameTemplate: "googleapis/mcp-toolbox",
       extractVersionTemplate: "^v(?<version>.*)$",
     }
   ]

--- a/.github/workflows/mirror-changelog.yml
+++ b/.github/workflows/mirror-changelog.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   add-release-notes:
-    if: github.actor == 'renovate-bot' && startsWith(github.head_ref, 'renovate/googleapis-genai-toolbox')
+    if: github.actor == 'renovate-bot' && startsWith(github.head_ref, 'renovate/googleapis-mcp-toolbox')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -38,7 +38,7 @@ jobs:
             const prBody = context.payload.pull_request.body || '';
 
             // Extract the relevant changelog section
-            const startMarker = '<summary>googleapis/genai-toolbox';
+            const startMarker = '<summary>googleapis/mcp-toolbox';
             const endMarker = '</details>';
             const startIndex = prBody.indexOf(startMarker);
             const endIndex = prBody.indexOf(endMarker, startIndex);
@@ -98,8 +98,8 @@ jobs:
                 // To prevent this, we insert an invisible Unicode zero-width space (`\u200B`)
                 // between the '#' and the number in the link text. This breaks the parser's
                 // pattern matching without changing the visual appearance of the link.
-                // E.g., "[#1770](...)" becomes "[genai-toolbox#​1770](...)"
-                originalContent = originalContent.replace(/\[#(\d+)\](\([^)]+\))/g, '[genai-toolbox#\u200B$1]$2');
+                // E.g., "[#1770](...)" becomes "[mcp-toolbox#​1770](...)"
+                originalContent = originalContent.replace(/\[#(\d+)\](\([^)]+\))/g, '[mcp-toolbox#\u200B$1]$2');
                 
                 const lineAsLowerCase = originalContent.toLowerCase();
                 const hasPrefix = prefixesToFilter.some(prefix => lineAsLowerCase.includes(prefix));

--- a/.github/workflows/package-and-upload-assets.yml
+++ b/.github/workflows/package-and-upload-assets.yml
@@ -18,7 +18,7 @@ name: Package and Upload Release Assets
 env:
   PACKAGE_NAME: "sql-server"
   FILES_TO_PACKAGE: "gemini-extension.json SQL-SERVER.md LICENSE"
-  GCS_BUCKET_URL: "https://storage.googleapis.com/genai-toolbox/geminicli"
+  GCS_BUCKET_URL: "https://storage.googleapis.com/mcp-toolbox-for-databases/geminicli"
 
 on:
   release:

--- a/.github/workflows/presubmit-tests.yml
+++ b/.github/workflows/presubmit-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install toolbox binary
         run: |
           VERSION=$(cat toolbox_version.txt)
-          curl -L -o toolbox "https://storage.googleapis.com/genai-toolbox/v${VERSION}/linux/amd64/toolbox"
+          curl -L -o toolbox "https://storage.googleapis.com/mcp-toolbox-for-databases/v${VERSION}/linux/amd64/toolbox"
           chmod +x toolbox
 
       - name: Install Extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,21 +19,21 @@
 
 ### Features
 
-* **deps:** update dependency googleapis/genai-toolbox to v0.25.0 ([#66](https://github.com/gemini-cli-extensions/sql-server/issues/66)) ([7ccba65](https://github.com/gemini-cli-extensions/sql-server/commit/7ccba656ad090805c02200b97b74d449adc963ef))
+* **deps:** update dependency googleapis/mcp-toolbox to v0.25.0 ([#66](https://github.com/gemini-cli-extensions/sql-server/issues/66)) ([7ccba65](https://github.com/gemini-cli-extensions/sql-server/commit/7ccba656ad090805c02200b97b74d449adc963ef))
 
 ## [0.1.3](https://github.com/gemini-cli-extensions/sql-server/compare/0.1.2...0.1.3) (2025-12-09)
 
 
 ### Features
 
-* **tool/mssql:** Set default host and port for MSSQL source ([genai-toolbox#​1943](https://redirect.github.com/googleapis/genai-toolbox/issues/1943)) ([7a9cc63](https://redirect.github.com/googleapis/genai-toolbox/commit/7a9cc633768d9ae9a7ff8230002da69d6a36ca86)) ([88756be](https://github.com/gemini-cli-extensions/sql-server/commit/88756bee8851330eb3e3701f10e95f4c7d44476e))
+* **tool/mssql:** Set default host and port for MSSQL source ([mcp-toolbox#​1943](https://redirect.github.com/googleapis/mcp-toolbox/issues/1943)) ([7a9cc63](https://redirect.github.com/googleapis/mcp-toolbox/commit/7a9cc633768d9ae9a7ff8230002da69d6a36ca86)) ([88756be](https://github.com/gemini-cli-extensions/sql-server/commit/88756bee8851330eb3e3701f10e95f4c7d44476e))
 
 ## [0.1.2](https://github.com/gemini-cli-extensions/sql-server/compare/0.1.1...0.1.2) (2025-10-17)
 
 
 ### Features
 
-* **deps:** update dependency googleapis/genai-toolbox to v0.17.0 ([#32](https://github.com/gemini-cli-extensions/sql-server/issues/32)) ([a72eecf](https://github.com/gemini-cli-extensions/sql-server/commit/a72eecf6fa6e5dc3d7b1b8f2684329c80ecba186))
+* **deps:** update dependency googleapis/mcp-toolbox to v0.17.0 ([#32](https://github.com/gemini-cli-extensions/sql-server/issues/32)) ([a72eecf](https://github.com/gemini-cli-extensions/sql-server/commit/a72eecf6fa6e5dc3d7b1b8f2684329c80ecba186))
 
 ## [0.1.1](https://github.com/gemini-cli-extensions/sql-server/compare/0.1.0...0.1.1) (2025-09-30)
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -33,7 +33,7 @@ The core logic for this extension is handled by a pre-built `toolbox` binary. Th
     VERSION=$(cat toolbox_version.txt)
 
     # Example for macOS/amd64
-    curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/geminicli/v$VERSION/darwin/amd64/toolbox
+    curl -L -o toolbox https://storage.googleapis.com/mcp-toolbox-for-databases/geminicli/v$VERSION/darwin/amd64/toolbox
     chmod +x toolbox
     ```
     Adjust the URL for your operating system (`linux/amd64`, `darwin/arm64`, `windows/amd64`).

--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ Common issues:
 
 * "✖ Error during discovery for server: MCP error -32000: Connection closed": The database connection has not been established. Ensure your configuration is set via environment variables.
 * "✖ MCP ERROR: Error: spawn /Users/USER/.gemini/extensions/sql-server/toolbox ENOENT": The Toolbox binary did not download correctly. Ensure you are using Gemini CLI v0.6.0+.
-* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://googleapis.github.io/mcp-toolbox/getting-started/introduction/#installing-the-server) for more information.
+* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://mcp-toolbox.dev/documentation/introduction/#install-toolbox) for more information.

--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ Common issues:
 
 * "✖ Error during discovery for server: MCP error -32000: Connection closed": The database connection has not been established. Ensure your configuration is set via environment variables.
 * "✖ MCP ERROR: Error: spawn /Users/USER/.gemini/extensions/sql-server/toolbox ENOENT": The Toolbox binary did not download correctly. Ensure you are using Gemini CLI v0.6.0+.
-* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://googleapis.github.io/genai-toolbox/getting-started/introduction/#installing-the-server) for more information.
+* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://googleapis.github.io/mcp-toolbox/getting-started/introduction/#installing-the-server) for more information.


### PR DESCRIPTION
Note: link checker will fail until the `genai-toolbox` repository rename is complete.