### PR TITLE
feat: adopt Agent Plugin spec and generate harness manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "sql-server",
+  "owner": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "metadata": {
+    "description": "Connect and interact with a SQL Server database and data."
+  },
+  "plugins": [
+    {
+      "name": "sql-server",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,63 @@
+{
+  "name": "sql-server",
+  "version": "0.1.6",
+  "description": "Connect to SQL Server",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/sql-server",
+  "license": "Apache-2.0",
+  "userConfig": {
+    "mssql_host": {
+      "title": "Host",
+      "description": "Host or IP address of the SQL Server",
+      "type": "string",
+      "sensitive": false
+    },
+    "mssql_port": {
+      "title": "Port",
+      "description": "Port number of the SQL Server",
+      "type": "string",
+      "sensitive": false
+    },
+    "mssql_database": {
+      "title": "Database",
+      "description": "Name of the database",
+      "type": "string",
+      "sensitive": false
+    },
+    "mssql_user": {
+      "title": "User",
+      "description": "Username of the database user",
+      "type": "string",
+      "sensitive": false
+    },
+    "mssql_password": {
+      "title": "Password",
+      "description": "Password of the database user",
+      "type": "string",
+      "sensitive": true
+    }
+  },
+  "mcpServers": {
+    "sql_server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "mssql",
+        "--stdio"
+      ],
+      "env": {
+        "MSSQL_HOST": "${user_config.mssql_host}",
+        "MSSQL_PORT": "${user_config.mssql_port}",
+        "MSSQL_DATABASE": "${user_config.mssql_database}",
+        "MSSQL_USER": "${user_config.mssql_user}",
+        "MSSQL_PASSWORD": "${user_config.mssql_password}"
+      },
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+    }
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -56,8 +56,7 @@
         "MSSQL_DATABASE": "${user_config.mssql_database}",
         "MSSQL_USER": "${user_config.mssql_user}",
         "MSSQL_PASSWORD": "${user_config.mssql_password}"
-      },
-      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+      }
     }
   }
 }

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -9,7 +9,6 @@
         "mssql",
         "--stdio"
       ],
-      "cwd": "${PLUGIN_ROOT}",
       "env_vars": [
         "MSSQL_HOST",
         "MSSQL_PORT",

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "sql_server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "mssql",
+        "--stdio"
+      ],
+      "cwd": "${PLUGIN_ROOT}",
+      "env_vars": [
+        "MSSQL_HOST",
+        "MSSQL_PORT",
+        "MSSQL_DATABASE",
+        "MSSQL_USER",
+        "MSSQL_PASSWORD"
+      ]
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "sql-server",
+  "version": "0.1.6",
+  "description": "Connect to SQL Server",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/sql-server",
+  "license": "Apache-2.0",
+  "mcpServers": "./.codex-plugin/.mcp.json"
+}

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Learn more about [Gemini CLI Extensions](https://github.com/google-gemini/gemini
 
 Before you begin, ensure you have the following:
 
-* [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed with version **+v0.6.0**.
-* Setup Gemini CLI [Authentication](https://github.com/google-gemini/gemini-cli/tree/main?tab=readme-ov-file#-authentication-options).
+* One of the supported agent harnesses, installed and authenticated:
+  * [Gemini CLI](https://github.com/google-gemini/gemini-cli) (v0.6.0+)
+  * [Claude Code](https://code.claude.com)
+  * [Codex](https://developers.openai.com/codex)
+  * [Antigravity CLI](https://antigravity.google)
 * [Node.js](https://nodejs.org/) (the MCP server runs via `npx`).
 * A running SQL Server instance.
 * A user with database-level permissions to execute queries.
@@ -34,15 +37,39 @@ Before you begin, ensure you have the following:
 
 ### Installation
 
-To install the extension, use the command:
+All harnesses use the same plugin; the MCP server runs via `npx` (no binary to download). Install with your harness of choice:
+
+**Gemini CLI**
 
 ```bash
 gemini extensions install https://github.com/gemini-cli-extensions/sql-server
 ```
 
+**Claude Code**
+
+```bash
+claude plugin marketplace add gemini-cli-extensions/sql-server
+claude plugin install sql-server@sql-server
+```
+
+**Codex**
+
+```bash
+codex plugin marketplace add gemini-cli-extensions/sql-server
+codex plugin add sql-server@sql-server
+```
+
+**Antigravity**
+
+```bash
+agy plugin install https://github.com/gemini-cli-extensions/sql-server
+```
+
+See [Configuration](#configuration) for how each harness supplies the connection settings.
+
 ### Configuration
 
-You will be prompted to configure the following settings during installation. These settings are saved in an `.env` file within the extension's directory.
+The plugin connects to SQL Server using these settings:
 
 *   `MSSQL_HOST`: (Optional) The SQL Server host. Defaults to `localhost`.
 *   `MSSQL_PORT`: (Optional) The SQL Server port. Defaults to `1433`.
@@ -50,19 +77,11 @@ You will be prompted to configure the following settings during installation. Th
 *   `MSSQL_USER`: The database username.
 *   `MSSQL_PASSWORD`: The password for the database user.
 
-To view or update your configuration:
+How you supply them depends on the harness:
 
-**List Settings:**
-*   Terminal: `gemini extensions list`
-*   Gemini CLI: `/extensions list`
-
-**Update Settings:**
-*   Terminal: `gemini extensions config sql-server [setting name] [--scope <scope>]`
-    *   `setting name`: (Optional) The single setting to configure.
-    *   `scope`: (Optional) The scope of the setting in (`user` or `workspace`). Defaults to `user`.
-*   Currently, you must restart the Gemini CLI for changes to take effect. We recommend using `gemini --resume` to resume your session.
-
-Alternatively, you can manually set these environment variables before starting the Gemini CLI:
+*   **Gemini CLI**: prompted on install and saved to the extension's `.env`. View or update later with `gemini extensions list` / `gemini extensions config sql-server [setting] [--scope user|workspace]` (restart the CLI to apply).
+*   **Claude Code**: pass `--config KEY=VALUE` on install (repeatable), or run `/plugin` inside Claude Code.
+*   **Codex** and **Antigravity**: export the variables in your shell before starting:
 
 #### PowerShell
 ```powershell

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "sql_server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "mssql",
+        "--stdio"
+      ],
+      "cwd": "${PLUGIN_ROOT}"
+    }
+  }
+}

--- a/mcp.json
+++ b/mcp.json
@@ -10,8 +10,7 @@
         "--prebuilt",
         "mssql",
         "--stdio"
-      ],
-      "cwd": "${PLUGIN_ROOT}"
+      ]
     }
   }
 }

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -8,8 +8,7 @@
         "--prebuilt",
         "mssql",
         "--stdio"
-      ],
-      "cwd": "${PLUGIN_ROOT}"
+      ]
     }
   }
 }

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "sql_server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "mssql",
+        "--stdio"
+      ],
+      "cwd": "${PLUGIN_ROOT}"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,47 @@
+{
+  "name": "sql-server",
+  "version": "0.1.6",
+  "description": "Connect to SQL Server",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/sql-server",
+  "license": "Apache-2.0",
+  "extensions": {
+    "com.google.cloud.data.agent-plugins": {
+      "config": [
+        {
+          "key": "MSSQL_HOST",
+          "title": "Host",
+          "description": "Host or IP address of the SQL Server"
+        },
+        {
+          "key": "MSSQL_PORT",
+          "title": "Port",
+          "description": "Port number of the SQL Server"
+        },
+        {
+          "key": "MSSQL_DATABASE",
+          "title": "Database",
+          "description": "Name of the database"
+        },
+        {
+          "key": "MSSQL_USER",
+          "title": "User",
+          "description": "Username of the database user"
+        },
+        {
+          "key": "MSSQL_PASSWORD",
+          "title": "Password",
+          "description": "Password of the database user",
+          "sensitive": true
+        }
+      ],
+      "gemini": {
+        "contextFileName": "SQL-SERVER.md",
+        "mcpServerName": "sql_server"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adopts the Agent Plugin spec (`plugin.json` + `mcp.json`) and generates the per-harness manifests (Gemini, Claude, Codex, Antigravity) + `marketplace.json`, plus a multi-harness README, so one plugin works across all four.

Generated with `agent-plugin-sync`; validate passes.
