### PR TITLE
ci: point Renovate and release-please at the source manifests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,9 +29,17 @@
   ],
   customManagers: [
     {
-      // Track the npm toolbox server pinned in the extension's MCP command.
+      // Track the npm toolbox server pinned in the MCP command. The version is
+      // listed in the source (mcp.json) and repeated in every generated
+      // manifest, so all of them are bumped in one PR.
       customType: "regex",
-      managerFilePatterns: ["/gemini-extension\\.json$/"],
+      managerFilePatterns: [
+        "/mcp\\.json$/",
+        "/mcp_config\\.json$/",
+        "/gemini-extension\\.json$/",
+        "/\\.claude-plugin/plugin\\.json$/",
+        "/\\.codex-plugin/\\.mcp\\.json$/",
+      ],
       matchStrings: ["@toolbox-sdk/server@(?<currentValue>[\\d\\.]+)"],
       datasourceTemplate: "npm",
       depNameTemplate: "@toolbox-sdk/server",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,7 +30,22 @@
       "extra-files": [
         {
           "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "gemini-extension.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
           "jsonpath": "$.version"
         }
       ]


### PR DESCRIPTION
Both automations were bumping only `gemini-extension.json`, so the source (`plugin.json` + `mcp.json`) and the other generated manifests drifted.